### PR TITLE
API - handle synonym empty string data issue

### DIFF
--- a/namex-solr-api/src/namex_solr_api/models/solr_synonym_list.py
+++ b/namex-solr-api/src/namex_solr_api/models/solr_synonym_list.py
@@ -91,6 +91,12 @@ class SolrSynonymList(Base):
     @staticmethod
     def create_or_replace(synonym_type: SolrSynonymList.Type, synonym: str, synonym_list: list[str], replace: bool):
         """Create, Add to, or replace the given synonym inside the db."""
+        # NOTE: References to empty synonyms in solr will break the synonym filters
+        if not synonym or not synonym.strip():
+            # Ignore references to empty strings etc.
+            return
+        # Filter out any empty strings etc.
+        synonym_list = [syn.strip() for syn in synonym_list if syn]
         if synonym in synonym_list:
             # remove any reference to itself
             synonym_list.remove(synonym)
@@ -110,7 +116,7 @@ class SolrSynonymList(Base):
     def create_or_replace_all(synonyms: dict[str, list[str]], synonym_type: Type) -> list[str]:
         """Add or replace the given synonyms inside the db."""
         synonyms_updated = []
-        # TODO: confirm if words can span multiple synonym lists or not
+        # NOTE: Words should not span multiple synonym lists
         for synonym, synonym_list in synonyms.items():
             # NOTE: this will replace the exiting list
             SolrSynonymList.create_or_replace(synonym_type, synonym, synonym_list, True)

--- a/namex-solr-api/src/namex_solr_api/resources/internal/solr/update/synonyms.py
+++ b/namex-solr-api/src/namex_solr_api/resources/internal/solr/update/synonyms.py
@@ -82,6 +82,9 @@ def update_synonyms():
         # update solr synonym file
         if SolrSynonymList.Type.ALL in synonyms_updated:
             solr.create_or_update_synonyms(SolrSynonymList.Type.ALL, synonyms_updated[SolrSynonymList.Type.ALL])
+            # Reload the solr core so it will register any changes for new updates/imports. It will throw an error if there is some issue with the synonym lists.
+            # NOTE: Any existing docs will not pickup the new synonym changes until the next reindex
+            solr.reload_core()
 
         return jsonify({"message": "Update successful"}), HTTPStatus.OK
 

--- a/namex-solr-api/src/namex_solr_api/version.py
+++ b/namex-solr-api/src/namex_solr_api/version.py
@@ -42,7 +42,7 @@ Development release segment: .devN
 """
 import os
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 def _get_commit_hash():
     """Return the containers ref if present."""

--- a/namex-solr/solr/name_request/conf/managed-schema.xml
+++ b/namex-solr/solr/name_request/conf/managed-schema.xml
@@ -703,6 +703,8 @@
       <tokenizer name="whitespace"/>
       <filter name="lowercase"/>
       <filter name="managedSynonymGraph" managed="ALL"/>
+      <!-- May need to add this later. Docs say you need it, but so far it has no effect leaving it out -->
+      <!-- <filter name="flattenGraph" /> -->
       <filter name="asciiFolding"/>
       <filter name="classic"/>
     </analyzer>


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/

*Description of changes:*
fixes the synonyms breaking if an empty string is in one of the synonym lists (dev has a list with an empty string which causes all the synonym filters to break)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
