### PR TITLE
29879 update fuzzy matching for short terms in name_q_single from 1 to 0

### DIFF
--- a/namex-solr-api/src/namex_solr_api/resources/v1/search.py
+++ b/namex-solr-api/src/namex_solr_api/resources/v1/search.py
@@ -115,7 +115,7 @@ def possible_conflict_names():
             query_fuzzy_fields={
                 NameField.NAME_Q: {"short": 1, "long": 2},
                 NameField.NAME_Q_AGRO: {"short": 1, "long": 2},
-                NameField.NAME_Q_SINGLE: {"short": 1, "long": 2}
+                NameField.NAME_Q_SINGLE: {"short": 0, "long": 2}
             },
             query_synonym_fields={
                 NameField.NAME_Q_SYN: "child"


### PR DESCRIPTION
*Issue:*https://github.com/bcgov/entity/issues/
https://github.com/bcgov/entity/issues/29879

*Description of changes:*
update fuzzy matching for short terms in name_q_single from 1 to 0 to improve result relevance

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
