### PR TITLE
fix: include historical coprs in COLIN and LEAR imports

### DIFF
--- a/namex-solr-importer/src/namex_solr_importer/utils/data_collection.py
+++ b/namex-solr-importer/src/namex_solr_importer/utils/data_collection.py
@@ -70,7 +70,7 @@ def collect_colin_data():
             and cs.end_event_id is null
             and cn.end_event_id is null
             and cn.corp_name_typ_cd in ('CO', 'NB')
-            and cos.op_state_typ_cd in ('ACT','HLD')
+            and cos.op_state_typ_cd in ('ACT','HLD','HIS')
         """)
     return cursor
 
@@ -92,7 +92,7 @@ def collect_lear_data() -> CursorResult:
         LEFT JOIN jurisdictions j on j.business_id = b.id
         WHERE legal_type in ({_get_stringified_list_for_sql('CONFLICT_LEGAL_TYPES')})
             and legal_type in ({_get_stringified_list_for_sql('MODERNIZED_LEGAL_TYPES')})
-            and state in ('ACTIVE')
+            and state in ('ACTIVE', 'HISTORICAL')
         """))
 
 


### PR DESCRIPTION
bcgov/entity#32988

Updated the COLIN/LEAR importer queries to include historical entities during partial imports.

##problem before
Some historical entity scenarios were remaining locked in the names pool even after the entity becomes HISTORICAL in Registry/backend.

Investigation suggest partial imports only process active entities, which can leave stale possible_conflicts records in Solr until a full reindex occurs.

##Change
Updated Lear import query to include HISTORICAL
Updated COLIN import query to include HIS.

##Expected Result
Historical entities should now be included during partial imports so Solr can receive/update the historical state.

##Validation
Local pytest run completed succeessfully
Local investigation confirmed importer flow sends possible conflicts payload through Solr import path





*Issue:*https://github.com/bcgov/entity/issues/

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the namex license (Apache 2.0).
