### PR TITLE
Ticket #32988 fix: treat LEAR-consumed NRs as CONSUMED in Solr import

### DIFF
--- a/namex-solr-importer/src/namex_solr_importer/utils/data_collection.py
+++ b/namex-solr-importer/src/namex_solr_importer/utils/data_collection.py
@@ -102,8 +102,12 @@ def collect_namex_data() -> CursorResult:
     conn = namex_db.db.engine.connect()
     current_app.logger.debug("Collecting NameX data...")
     return conn.execute(text("""
-        SELECT r.nr_num, r.corp_num,
-            CASE WHEN r.corp_num IS NOT NULL THEN 'CONSUMED' ELSE r.state_cd END as state,
+        SELECT r.nr_num,
+            COALESCE(n.corp_num, r.corp_num) as corp_num,
+            CASE
+                WHEN COALESCE(n.corp_num, r.corp_num) IS NOT NULL THEN 'CONSUMED'
+                ELSE r.state_cd
+            END as state,
             r.xpro_jurisdiction as jurisdiction,
             r.submitted_date as start_date, r.submit_count,
             n.name, n.choice,

--- a/namex-solr-importer/src/namex_solr_importer/utils/data_collection.py
+++ b/namex-solr-importer/src/namex_solr_importer/utils/data_collection.py
@@ -102,7 +102,9 @@ def collect_namex_data() -> CursorResult:
     conn = namex_db.db.engine.connect()
     current_app.logger.debug("Collecting NameX data...")
     return conn.execute(text("""
-        SELECT r.nr_num, r.corp_num, r.state_cd as state, r.xpro_jurisdiction as jurisdiction,
+        SELECT r.nr_num, r.corp_num,
+            CASE WHEN r.corp_num IS NOT NULL THEN 'CONSUMED' ELSE r.state_cd END as state,
+            r.xpro_jurisdiction as jurisdiction,
             r.submitted_date as start_date, r.submit_count,
             n.name, n.choice,
             CASE n.state


### PR DESCRIPTION
bcgov/entity#32988

 Problem
When LEAR incorporates a company using an NR, it sets `corp_num` on  the namex `requests` record but does NOT change `state_cd` to `CONSUMED`. The importer reads `state_cd` directly, so consumed NRs are always imported as `APPROVED` and continue blocking name conflict searches.

Proposed Fix
In collect_namex_data()`, use  CASE WHEN r.corp_num IS NOT NULL THEN 'CONSUMED
ELSE r.state_cd END` to detect LEAR consumption. The search filter 
conflict_states = ["ACTIVE", "APPROVED", "CONDITION"]` already excludes 
CONSUMED, so these NRs will be correctly filtered out after the next 
importer run.

 Files changed
 namex-solr-importer/src/namex_solr_importer/utils/data_collection.py