### PR TITLE
#32842 fix: enable phonetic term injection for readable highlights

### DIFF
--- a/namex-solr/solr/name_request/conf/managed-schema.xml
+++ b/namex-solr/solr/name_request/conf/managed-schema.xml
@@ -479,7 +479,7 @@
     <fieldType name="phonetic_en" stored="false" indexed="true" class="solr.TextField" >
       <analyzer>
         <tokenizer name="standard"/>
-        <filter name="doubleMetaphone" inject="false"/>
+        <filter name="doubleMetaphone" inject="true"/>
       </analyzer>
     </fieldType>
 


### PR DESCRIPTION
https://github.com/bcgov/entity/issues/32842
Changes DoubleMetaphone filter from inject='false' to inject='true' to preserve original terms alongside phonetic tokens. This allows Solr to highlight readable search terms instead of phonetic codes, enabling the API to properly extract and return phonetic matches in the highlighting response.
