### PR TITLE
#32842 fix: separate index and query analyzers for phonetic highlighting

### DIFF
--- a/namex-solr/solr/name_request/conf/managed-schema.xml
+++ b/namex-solr/solr/name_request/conf/managed-schema.xml
@@ -477,9 +477,12 @@
 
     <dynamicField name="*_phon_en" type="phonetic_en"  indexed="true"  stored="true"/>
     <fieldType name="phonetic_en" stored="false" indexed="true" class="solr.TextField" >
-      <analyzer>
+      <analyzer type="index">
         <tokenizer name="standard"/>
         <filter name="doubleMetaphone" inject="true"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer name="standard"/>
       </analyzer>
     </fieldType>
 


### PR DESCRIPTION
Adds separate analyzer configurations to the phonetic_en field type:
- Index analyzer: applies DoubleMetaphone for phonetic matching (FARM ↔ PHARM)
- Query analyzer: uses standard tokenizer for readable highlighting (shows 'FARM' not 'FM')
