### PR TITLE
#32842 fix: apply DoubleMetaphone to query analyzer for phonetic matching

### DIFF
--- a/namex-solr/solr/name_request/conf/managed-schema.xml
+++ b/namex-solr/solr/name_request/conf/managed-schema.xml
@@ -483,6 +483,7 @@
       </analyzer>
       <analyzer type="query">
         <tokenizer name="standard"/>
+        <filter name="doubleMetaphone" inject="true"/>
       </analyzer>
     </fieldType>
 


### PR DESCRIPTION
Adds DoubleMetaphone filter to the query analyzer in phonetic_en field type. This ensures query terms are converted to phonetic hashes at query time, matching the indexed phonetic hashes created during indexing. Enables FARM ↔ PHARM bidirectional matching and readable highlighting in API responses.

Both index and query analyzers now apply DoubleMetaphone with inject='true', ensuring phonetic matching while preserving original terms for highlighting.


