### PR TITLE
#32842 fix: enable storage of phonetic field in Solr schema

### DIFF
--- a/namex-solr/solr/name_request/conf/managed-schema.xml
+++ b/namex-solr/solr/name_request/conf/managed-schema.xml
@@ -476,7 +476,7 @@
     </fieldType>
 
     <dynamicField name="*_phon_en" type="phonetic_en"  indexed="true"  stored="true"/>
-    <fieldType name="phonetic_en" stored="false" indexed="true" class="solr.TextField" >
+    <fieldType name="phonetic_en" stored="true" indexed="true" class="solr.TextField" >
       <analyzer type="index">
         <tokenizer name="standard"/>
         <filter name="doubleMetaphone" inject="true"/>


### PR DESCRIPTION
The phonetic_en fieldType had stored="false" which prevented Solr from storing and highlighting phonetic matches. The dynamic field declared stored="true" but the type definition conflicted with stored="false".

Change phonetic_en fieldType to stored="true" to enable proper storage and highlighting of phonetic field values during search.

