### PR TITLE
Feature/32842 phonetic doublemetaphone

### DIFF
--- a/namex-solr-api/pyproject.toml
+++ b/namex-solr-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "namex-solr-api"
-version = "1.0.4"
+version = "1.0.5"
 description = ""
 authors = [
     {name = "Kial Jinnah",email = "kialj876@gmail.com"}

--- a/namex-solr-api/src/namex_solr_api/resources/v1/search.py
+++ b/namex-solr-api/src/namex_solr_api/resources/v1/search.py
@@ -130,7 +130,7 @@ def possible_conflict_names():
         )
 
         results = namex_search(params, solr, True)
-        solr_highlighting: dict[str, dict[str, list[str]]] = results.get("highlighting")
+        solr_highlighting: dict[str, dict[str, list[str]]] = results.get("highlighting", {})
         docs = []
         for result in results.get("response", {}).get("docs"):
             def split_highlights(highlights: list[str]):
@@ -141,7 +141,7 @@ def possible_conflict_names():
                     resp += [term for term in clean.upper().split(" ") if term]
                 return resp
 
-            highlight_raw = solr_highlighting[result[NameField.UNIQUE_KEY.value]]
+            highlight_raw = solr_highlighting.get(result[NameField.UNIQUE_KEY.value], {})
             exact_highlights = []
             stem_highlights = []
             phonetic_highlights = []

--- a/namex-solr-api/src/namex_solr_api/services/namex_solr/utils/namex_search_helper.py
+++ b/namex-solr-api/src/namex_solr_api/services/namex_solr/utils/namex_search_helper.py
@@ -99,8 +99,8 @@ def namex_search(params: QueryParams, solr: NamexSolr, is_name_search: bool):
                          solr=solr)
 
     resp: dict[str, dict[str, dict[str, list[str]]]] = solr.query(solr_payload, params.start, params.rows)
+    parsed_highlighting = {}
     if solr_highlighting := resp.get('highlighting'):
-        parsed_highlighting = {}
         for result_id, result in solr_highlighting.items():
             parsed_highlighting[result_id] = {}
             for field_enum in params.highlighted_fields:
@@ -108,7 +108,7 @@ def namex_search(params: QueryParams, solr: NamexSolr, is_name_search: bool):
                     parsed_highlighting[result_id][field_enum.value] = []
                     for highlight in field_highlights:
                         parsed_highlighting[result_id][field_enum.value] += namex_search_parse_highlighting(highlight)
-        resp['highlighting'] = parsed_highlighting
+    resp['highlighting'] = parsed_highlighting
     return resp
 
 

--- a/namex-solr/solr/name_request/conf/managed-schema.xml
+++ b/namex-solr/solr/name_request/conf/managed-schema.xml
@@ -744,6 +744,7 @@
   <field name="name_q_stem_highlight" type="text_stemmed_agro" indexed="true" stored="true"/>
   <field name="name_q_synonym" type="synonym" indexed="true" stored="true"/>
   <field name="name_q_xtra" type="text_extra" indexed="true" stored="false"/>
+  <field name="name_q_phon_en" type="phonetic_en" indexed="true" stored="true"/>
   <field name="name_state" type="string" docValues="true" indexed="true" stored="true"/>
   <field name="submit_count" type="pint" indexed="false" stored="true"/>
   <field name="parent_id" type="string" indexed="false" stored="true"/>

--- a/namex-solr/solr/name_request_follower/conf/solrconfig.xml
+++ b/namex-solr/solr/name_request_follower/conf/solrconfig.xml
@@ -650,7 +650,7 @@
        <str name="echoParams">explicit</str>
        <str name="wt">json</str>
        <str name="indent">true</str>
-       <str name="df">text</str>
+       <str name="df">_text_</str>
      </lst>
   </requestHandler>
 
@@ -666,7 +666,7 @@
 
   <initParams path="/update/**,/query,/select,/tvrh,/elevate,/spell,update">
     <lst name="defaults">
-      <str name="df">text</str>
+      <str name="df">_text_</str>
     </lst>
   </initParams>
 


### PR DESCRIPTION
https://github.com/bcgov/entity/issues/32842

Fix defensive coding gap that prevented the phonetic field from being extracted and returned in API responses.

Changes
- Initialize `parsed_highlighting` dict outside conditional block to ensure `resp['highlighting']` is always set
- Replace direct dictionary indexing with safe `.get()` access to prevent TypeErrors
- Version bump: 1.0.4 → 1.0.5